### PR TITLE
Unet

### DIFF
--- a/conf/base/parameters_unet.yml
+++ b/conf/base/parameters_unet.yml
@@ -1,12 +1,169 @@
 configs:
-  skip_unet_masks: False
+  # Se True, pula a geração das máscaras pela UNet.
+  skip_unet_masks: false
 
-  # Parâmetros do Unet
+  # Parâmetros da UNet para detecção de nuvens/sombras.
   unet:
-    model_weights: "UNetMobV2_V2.pt"   # Atualize com o caminho real, se necessário
-    input_size: [512, 512, 13]           # Exemplo para Sentinel-2 com 13 canais
-    threshold: 0.5    
-    cloud_clear_class: 0                  # Classe que representa pixels sem nuvens                 
-    cloud_thick_class: 1                     # Classe que representa nuvens grossas
-    cloud_thin_class: 2                      # Classe que representa nuvens finas
-    cloud_shadow_class: 3              # Classe que representa sombras de nuvens
+    # Escolha do backbone do modelo.
+    # "regnetz_d8" usa UNet (segmentation_models_pytorch) com encoder RegNetZ D8.
+    # "mobilenet_v2" mantém o comportamento anterior.
+    architecture: regnetz_d8
+
+    # Arquivo local de pesos. Se não existir, o loader baixa automaticamente.
+    model_weights: "unet_regnetz_d8.pth"
+
+    # Tamanho de entrada esperado pelo modelo: H×W×C (C=13 bandas Sentinel-2 L1C).
+    input_size: [512, 512, 13]
+
+    # Mapeamento de classes do modelo (CloudSEN12/CloudSEN12+):
+    # 0=clear, 1=thick cloud, 2=thin cloud, 3=cloud shadow.
+    classes:
+      clear: 0
+      cloud_thick: 1
+      cloud_thin: 2
+      cloud_shadow: 3
+
+    # Índices usados na composição das máscaras (compatível com nodes.py / inferência).
+    cloud_thick_class: 1
+    cloud_thin_class: 2
+    cloud_shadow_class: 3
+
+    # Mantido por compatibilidade (a inferência usa argmax sem threshold).
+    threshold: 0.5
+
+    # Metadados do dataset / bandas.
+    data:
+      # Sentinel-2 Nível 1C (13 bandas).
+      product: "COPERNICUS/S2"
+      level: "L1C"
+
+      # Resolução-alvo (m). Se necessário, reamostrar bandas nativas 20m/60m para 10m.
+      target_resolution_m: 10
+
+      # Normalização de entrada (refletância em float) — dividir por 10.000.
+      input_normalization:
+        type: "scale_divide"
+        scale_factor: 0.0001
+
+      # Ordem das bandas no cubo (C=13), mapeando índices 0..12.
+      # Esta ordem precisa casar com a ordem dos canais no .tif de entrada.
+      band_order: [B01, B02, B03, B04, B05, B06, B07, B08, B8A, B09, B10, B11, B12]
+
+      # Metadados das bandas Sentinel-2 L1C.
+      bands:
+        - id: B01
+          common_name: "Coastal aerosol"
+          description: "Band 1 - Coastal aerosol - 60m"
+          center_wavelength_nm: 443.5
+          fwhm_nm: 17.0
+          index: 0
+          native_resolution_m: 60
+          scale_factor: 0.0001
+
+        - id: B02
+          common_name: "Blue"
+          description: "Band 2 - Blue - 10m"
+          center_wavelength_nm: 496.5
+          fwhm_nm: 53.0
+          index: 1
+          native_resolution_m: 10
+          scale_factor: 0.0001
+
+        - id: B03
+          common_name: "Green"
+          description: "Band 3 - Green - 10m"
+          center_wavelength_nm: 560.0
+          fwhm_nm: 34.0
+          index: 2
+          native_resolution_m: 10
+          scale_factor: 0.0001
+
+        - id: B04
+          common_name: "Red"
+          description: "Band 4 - Red - 10m"
+          center_wavelength_nm: 664.5
+          fwhm_nm: 29.0
+          index: 3
+          native_resolution_m: 10
+          scale_factor: 0.0001
+
+        - id: B05
+          common_name: "Red edge 1"
+          description: "Band 5 - Vegetation red edge 1 - 20m"
+          center_wavelength_nm: 704.5
+          fwhm_nm: 13.0
+          index: 4
+          native_resolution_m: 20
+          scale_factor: 0.0001
+
+        - id: B06
+          common_name: "Red edge 2"
+          description: "Band 6 - Vegetation red edge 2 - 20m"
+          center_wavelength_nm: 740.5
+          fwhm_nm: 13.0
+          index: 5
+          native_resolution_m: 20
+          scale_factor: 0.0001
+
+        - id: B07
+          common_name: "Red edge 3"
+          description: "Band 7 - Vegetation red edge 3 - 20m"
+          center_wavelength_nm: 783.0
+          fwhm_nm: 18.0
+          index: 6
+          native_resolution_m: 20
+          scale_factor: 0.0001
+
+        - id: B08
+          common_name: "NIR"
+          description: "Band 8 - Near infrared - 10m"
+          center_wavelength_nm: 840.0
+          fwhm_nm: 114.0
+          index: 7
+          native_resolution_m: 10
+          scale_factor: 0.0001
+
+        - id: B8A
+          common_name: "Red edge 4"
+          description: "Band 8A - Vegetation red edge 4 - 20m"
+          center_wavelength_nm: 864.5
+          fwhm_nm: 19.0
+          index: 8
+          native_resolution_m: 20
+          scale_factor: 0.0001
+
+        - id: B09
+          common_name: "Water vapor"
+          description: "Band 9 - Water vapor - 60m"
+          center_wavelength_nm: 945.0
+          fwhm_nm: 18.0
+          index: 9
+          native_resolution_m: 60
+          scale_factor: 0.0001
+
+        - id: B10
+          common_name: "Cirrus"
+          description: "Band 10 - Cirrus - 60m"
+          center_wavelength_nm: 1375.5
+          fwhm_nm: 31.0
+          index: 10
+          native_resolution_m: 60
+          scale_factor: null  # N/A no produto original
+
+        - id: B11
+          common_name: "SWIR 1"
+          description: "Band 11 - Shortwave infrared 1 - 20m"
+          center_wavelength_nm: 1613.5
+          fwhm_nm: 89.0
+          index: 11
+          native_resolution_m: 20
+          scale_factor: 0.0001
+
+        - id: B12
+          common_name: "SWIR 2"
+          description: "Band 12 - Shortwave infrared 2 - 20m"
+          center_wavelength_nm: 2199.5
+          fwhm_nm: 173.0
+          index: 12
+          native_resolution_m: 20
+          scale_factor: 0.0001

--- a/conf/base/parameters_unet.yml
+++ b/conf/base/parameters_unet.yml
@@ -28,7 +28,7 @@ configs:
     cloud_thin_class: 2
     cloud_shadow_class: 3
 
-    # Mantido por compatibilidade (a inferência usa argmax sem threshold).
+    # Mantido por compatibilidade (a inferência dos modelos usa argmax sem threshold).
     threshold: 0.5
 
     # Metadados do dataset / bandas.

--- a/requirements.txt
+++ b/requirements.txt
@@ -195,10 +195,12 @@ ruamel.yaml.clib==0.2.12
 s3fs==2024.12.0
 scikit-learn==1.5.2
 scipy==1.14.1
+scikit-image==0.25.2
 secure==1.0.1
 segmentation-mask-overlay==0.4.4
 semver==2.13.0
 Send2Trash==1.8.3
+segmentation_models_pytorch==0.3.0
 shapely==2.0.6
 six==1.17.0
 smmap==5.0.1
@@ -220,6 +222,7 @@ text-unidecode==1.3
 threadpoolctl==3.5.0
 tifffile==2025.1.10
 tinycss2==1.4.0
+timm>=0.9.2
 toml==0.10.2
 tomli==2.2.1
 tornado==6.4.2
@@ -245,5 +248,3 @@ widgetsnbextension==4.0.13
 wrapt==1.14.1
 yarl==1.18.3
 zipp==3.21.0
-segmentation_models_pytorch==0.3.0
-scikit-image==0.25.2

--- a/src/fmask_pipeline/pipelines/unet/nodes.py
+++ b/src/fmask_pipeline/pipelines/unet/nodes.py
@@ -1,17 +1,16 @@
-import glob
 import logging
-import os
 from pathlib import Path
+from typing import Any, Dict, Optional
 
-import numpy as np
-import rasterio
-import torch
 from tqdm import tqdm
 
-from utils.pytorch.pytorch_general_utils import torch_model_cloud_and_shadows_inference
+from utils.pytorch.pytorch_general_utils import (
+    torch_model_cloud_and_shadows_inference,
+)
 from utils.unet.unet_utils import load_unet_model
 
 logger = logging.getLogger(__name__)
+
 
 def apply_unet(
     toa_path: str,
@@ -19,59 +18,94 @@ def apply_unet(
     save_masks_path: str,
     save_plots_path: str,
     skip_masks: bool = False,
-    model_path: str = None,
-    unet_params: dict = None,
+    model_path: Optional[str] = None,
+    unet_params: Optional[Dict[str, Any]] = None,
     scale_factor: float = 1.0,
     *args,
     **kwargs,
-):
+) -> bool:
     """
-    Aplica a UNet para inferir máscaras de nuvem e sombra, combina com a máscara de água
-    (se existir) e salva o resultado como um único TIF e um PNG de visualização.
+    Aplica a UNet para inferir máscaras de nuvem e sombra, combina com a
+    máscara de água (se existir) e salva o resultado como um único TIF e um
+    PNG de visualização.
 
-    Args:
-        toa_path (str): Caminho base das imagens (TOA).
-        location_name (str): Nome do local/pasta.
-        save_masks_path (str): Caminho para salvar as máscaras TIF combinadas.
-        save_plots_path (str): Caminho para salvar os plots PNG combinados.
-        skip_masks (bool, opcional): Se True, pula a geração das máscaras. Default é False.
-         (str, opcional): Caminho do modelo UNet. Default é None.
-        unet_params (dict, opcional): Parâmetros adicionais para a UNet. Default é None.
+    Parâmetros
+    ----------
+    toa_path : str
+        Caminho base onde estão as imagens TOA (organizadas por `location_name`).
+    location_name : str
+        Nome da localidade/pasta das imagens.
+    save_masks_path : str
+        Caminho onde serão salvos os TIFs de máscara.
+    save_plots_path : str
+        Caminho onde serão salvos os PNGs de visualização das máscaras.
+    skip_masks : bool
+        Se True, pula a geração das máscaras.
+    model_path : Optional[str]
+        Caminho explícito para os pesos do modelo (opcional).
+    unet_params : Optional[Dict[str, Any]]
+        Dicionário com parâmetros do UNet. Chaves suportadas:
+        - "model_weights": caminho dos pesos (opcional; tem precedência sobre `model_path`)
+        - "architecture": "mobilenet_v2" | "regnetz_d8" (opcional)
+        - "cloud_thick_class": int (default=1)
+        - "cloud_thin_class": int (default=2)
+        - "cloud_shadow_class": int (default=3)
+    scale_factor : float
+        Fator multiplicativo aplicado nos valores de reflectância antes da inferência.
+
+    Retorno
+    -------
+    bool
+        True quando finaliza (ou quando `skip_masks=True`).
     """
     if skip_masks:
         logger.warning("Pular geração das máscaras com UNet")
         return True
 
-    unet_params = unet_params or {}
-    model_weights = unet_params.get("model_weights", None)
-    cloud_thick_class = unet_params.get("cloud_thick_class", 1)
-    cloud_thin_class = unet_params.get("cloud_thin_class", 2)
-    cloud_shadow_class = unet_params.get("cloud_shadow_class", 3)
+    params = unet_params or {}
 
-    # Carrega o modelo (priorizando o caminho definido em unet_params)
-    model = load_unet_model(model_weights if model_weights else model_path)
+    # Lê parâmetros do modelo / classes
+    model_weights = params.get("model_weights", model_path)
+    architecture = params.get("architecture", None)  # e.g. "regnetz_d8" | "mobilenet_v2"
+    cloud_thick_class = params.get("cloud_thick_class", 1)
+    cloud_thin_class = params.get("cloud_thin_class", 2)
+    cloud_shadow_class = params.get("cloud_shadow_class", 3)
 
-    # Procura os arquivos TIFF com 13 bandas usando pathlib
+    # Carrega o modelo respeitando a arquitetura solicitada (backward-compatible)
+    model = load_unet_model(model_path=model_weights, architecture=architecture)
+
+    # Procura os arquivos TIFF com 13 bandas
     inputs = list(Path(toa_path, location_name).rglob("*.tif"))
     total_tifs = len(inputs)
 
+    if total_tifs == 0:
+        logger.warning(
+            "Nenhum arquivo .tif encontrado em '%s/%s' para segmentação UNet.",
+            toa_path,
+            location_name,
+        )
+        return True
 
     with tqdm(
-        total=total_tifs, desc="Segmenting Clouds and Cloud Shadows - UNet", unit="images"
+        total=total_tifs,
+        desc="Segmenting Clouds and Cloud Shadows - UNet",
+        unit="images",
     ) as pbar:
         for inp in inputs:
-            # Define o nome do arquivo de saída com base na estrutura de diretórios
+            # Define o nome do arquivo de saída respeitando a estrutura atual
             file_parts = inp.parts[-2:]
             file_name = f"{location_name}/{file_parts[0]}/unet_mask_{inp.stem}"
+
+            # Inferência e salvamento das saídas
             torch_model_cloud_and_shadows_inference(
                 input_tif_path=inp,
                 save_mask_path=save_masks_path,
                 save_plot_path=save_plots_path,
                 save_file_name=file_name,
                 cloud_classes=[cloud_thick_class, cloud_thin_class],
-                cloud_shadows_classes=cloud_shadow_class,
+                cloud_shadows_classes=[cloud_shadow_class],  # lista para np.isin
                 model=model,
-                scale_factor=scale_factor
+                scale_factor=scale_factor,
             )
             pbar.update(1)
 

--- a/src/utils/unet/unet_utils.py
+++ b/src/utils/unet/unet_utils.py
@@ -1,5 +1,6 @@
 import logging
 from pathlib import Path
+from typing import Optional
 
 import requests
 import segmentation_models_pytorch as smp
@@ -7,45 +8,186 @@ import torch
 
 logger = logging.getLogger(__name__)
 
+# Pesos do modelo original (UNet com encoder MobileNet_v2)
+_MOBILENET_DEFAULT_URL = (
+    "https://huggingface.co/datasets/isp-uv-es/CloudSEN12Plus/"
+    "resolve/main/demo/models/UNetMobV2_V2.pt"
+)
+_MOBILENET_DEFAULT_FILENAME = "UNetMobV2_V2.pt"
 
-def download_model(model_url: str, model_path: Path) -> None:
-    """Realiza o download do modelo UNet a partir da URL fornecida."""
-    logger.info("Fazendo download do modelo UNet...")
-    response = requests.get(model_url, stream=True)
-    response.raise_for_status()
-    with open(model_path, "wb") as f:
-        for chunk in response.iter_content(chunk_size=8192):
-            f.write(chunk)
+# Pesos do novo modelo (UNet com encoder RegNetZ D8)
+_REGNETZ_D8_DEFAULT_URL = (
+    "https://huggingface.co/Burdenthrive/cloud-detection-unet-regnetzd8/"
+    "resolve/main/unet_regnetz_d8.pth"
+)
+_REGNETZ_D8_DEFAULT_FILENAME = "unet_regnetz_d8.pth"
 
 
-def load_unet_model(model_path: str = None):
+def download_model(model_url: str, model_path: Path, chunk_size: int = 8192) -> None:
     """
-    Carrega o modelo UNet (MobileNet_v2) com 13 bandas de entrada e 4 classes de saída.
-    Se o arquivo local não for encontrado, baixa automaticamente o modelo pré-treinado.
+    Faz o download de um arquivo de pesos de modelo para o caminho indicado.
+
+    Parameters
+    ----------
+    model_url : str
+        URL do arquivo de pesos.
+    model_path : Path
+        Caminho de destino para salvar o arquivo.
+    chunk_size : int
+        Tamanho do chunk para streaming.
     """
-    default_model_url = "https://huggingface.co/datasets/isp-uv-es/CloudSEN12Plus/resolve/main/demo/models/UNetMobV2_V2.pt"
-    default_model_filename = "UNetMobV2_V2.pt"
+    logger.info("Baixando pesos do modelo: %s", model_url)
+    model_path.parent.mkdir(parents=True, exist_ok=True)
+    with requests.get(model_url, stream=True, timeout=60) as r:
+        r.raise_for_status()
+        with open(model_path, "wb") as f:
+            for chunk in r.iter_content(chunk_size=chunk_size):
+                if chunk:
+                    f.write(chunk)
+    logger.info("Pesos salvos em: %s", model_path)
 
-    # Define o caminho do modelo utilizando Path
-    if model_path is None:
-        model_path = default_model_filename
-    model_path = Path(model_path)
 
-    # Se o arquivo não existir, realiza o download
-    if not model_path.exists():
-        download_model(default_model_url, model_path)
+def _ensure_weights(path: Path, url: str) -> None:
+    """
+    Garante que o arquivo de pesos exista localmente; caso contrário, faz o download.
+    """
+    if not path.exists():
+        logger.info("Arquivo de pesos não encontrado em '%s'. Será feito o download.", path)
+        download_model(url, path)
+    else:
+        logger.info("Usando pesos locais: %s", path)
 
-    # Cria a arquitetura da UNet
+
+def _load_state_dict_with_possible_prefix(
+    model: torch.nn.Module, state_dict: dict
+) -> None:
+    """
+    Carrega o state_dict no modelo. Caso as chaves estejam prefixadas com 'unet.'
+    (padrão comum quando a rede foi salva dentro de um wrapper), remove o prefixo
+    e tenta novamente. Por fim, realiza um load não estrito se necessário.
+    """
+    try:
+        model.load_state_dict(state_dict, strict=True)
+        return
+    except RuntimeError as e:
+        # Tenta remover o prefixo 'unet.' (como no wrapper de HF).
+        if any(k.startswith("unet.") for k in state_dict.keys()):
+            stripped = {k.replace("unet.", "", 1): v for k, v in state_dict.items()}
+            model.load_state_dict(stripped, strict=True)
+            return
+        logger.warning(
+            "Falha no carregamento estrito dos pesos (%s). Tentando modo não estrito.", e
+        )
+        model.load_state_dict(state_dict, strict=False)
+
+
+def load_unet_mobilenet_v2_model(model_path: Optional[str] = None) -> torch.nn.Module:
+    """
+    Carrega uma UNet (smp.Unet) com encoder MobileNet_v2,
+    13 canais de entrada (Sentinel‑2) e 4 classes de saída.
+
+    Parameters
+    ----------
+    model_path : Optional[str]
+        Caminho para o arquivo de pesos. Se None, usa o padrão.
+
+    Returns
+    -------
+    torch.nn.Module
+        Modelo PyTorch pronto para inferência (eval e sem gradientes).
+    """
+    path = Path(model_path or _MOBILENET_DEFAULT_FILENAME)
+    _ensure_weights(path, _MOBILENET_DEFAULT_URL)
+
     model = smp.Unet(
-        encoder_name="mobilenet_v2", encoder_weights=None, classes=4, in_channels=13
+        encoder_name="mobilenet_v2",
+        encoder_weights=None,
+        classes=4,
+        in_channels=13,
     )
-    # Carrega os pesos do modelo
-    state_dict = torch.load(str(model_path), map_location=torch.device("cpu"))
-    model.load_state_dict(state_dict)
+    state = torch.load(str(path), map_location=torch.device("cpu"))
+    _load_state_dict_with_possible_prefix(model, state)
 
-    # Desativa os gradientes e coloca o modelo em modo de avaliação
-    for param in model.parameters():
-        param.requires_grad = False
+    for p in model.parameters():
+        p.requires_grad = False
     model.eval()
     return model
 
+
+def load_unet_regnetz_d8_model(model_path: Optional[str] = None) -> torch.nn.Module:
+    """
+    Carrega uma UNet (smp.Unet) com encoder RegNetZ D8 (via TIMM),
+    13 canais de entrada e 4 classes de saída.
+
+    Parameters
+    ----------
+    model_path : Optional[str]
+        Caminho para o arquivo de pesos. Se None, usa o padrão do HF.
+
+    Returns
+    -------
+    torch.nn.Module
+        Modelo PyTorch pronto para inferência (eval e sem gradientes).
+    """
+    path = Path(model_path or _REGNETZ_D8_DEFAULT_FILENAME)
+    _ensure_weights(path, _REGNETZ_D8_DEFAULT_URL)
+
+    # Importante: o nome do encoder no segmentation_models_pytorch
+    # para os encoders do timm costuma usar o prefixo 'tu-'.
+    model = smp.Unet(
+        encoder_name="tu-regnetz_d8",
+        encoder_weights=None,
+        classes=4,
+        in_channels=13,
+    )
+    state = torch.load(str(path), map_location=torch.device("cpu"))
+    _load_state_dict_with_possible_prefix(model, state)
+
+    for p in model.parameters():
+        p.requires_grad = False
+    model.eval()
+    return model
+
+
+def load_unet_model(
+    model_path: Optional[str] = None,
+    architecture: Optional[str] = None,
+) -> torch.nn.Module:
+    """
+    Loader *backward-compatible* usado em toda a pipeline.
+
+    - Se `architecture` for informado, escolhe explicitamente o backbone.
+    - Caso contrário, tenta inferir a partir do nome do arquivo de pesos.
+    - Em último caso, usa o modelo padrão (MobileNet_v2).
+
+    Isso permite trocar apenas o `model_weights` no parameters.yml (por exemplo,
+    para "unet_regnetz_d8.pth") sem alterar o restante do código ou da pipeline.
+
+    Parameters
+    ----------
+    model_path : Optional[str]
+        Caminho para o arquivo de pesos (ou None para padrão).
+    architecture : Optional[str]
+        Nome do backbone. Exemplos: "mobilenet_v2", "regnetz_d8" (ou "tu-regnetz_d8").
+
+    Returns
+    -------
+    torch.nn.Module
+        Modelo PyTorch pronto para inferência.
+    """
+    arch = (architecture or "").lower()
+
+    # Escolha explícita por parâmetro
+    if arch in {"regnetz_d8", "tu-regnetz_d8", "regnetz", "regnetzd8"}:
+        return load_unet_regnetz_d8_model(model_path)
+    if arch in {"mobilenet_v2", "mobilenet"}:
+        return load_unet_mobilenet_v2_model(model_path)
+
+    # Inferência automática pelo nome do arquivo
+    if model_path:
+        name = Path(model_path).name.lower()
+        if "regnetz" in name or "regnet" in name or name.endswith("d8.pth"):
+            return load_unet_regnetz_d8_model(model_path)
+
+    # Fallback: modelo padrão (MobileNet_v2)
+    return load_unet_mobilenet_v2_model(model_path)


### PR DESCRIPTION
Adicionei suporte a um novo modelo UNet com encoder RegNetZ D8 para geração de máscaras de nuvem e sombra no pipeline Kedro.
As principais mudanças foram:

utils/unet/unet_utils.py

Criação da função load_unet_regnetz_d8_model para baixar, carregar e inicializar o modelo RegNetZ D8.

Atualização da função load_unet_model para selecionar dinamicamente entre mobilenet_v2 e regnetz_d8.

pipelines/unet/nodes.py

Alteração do nó apply_unet para aceitar o parâmetro architecture e chamar o loader correto.

Mantida compatibilidade com o modelo antigo (MobileNet_v2).

conf/base/parameters_unet.yml

Inclusão de configurações detalhadas do Sentinel-2 L1C (13 bandas, 10 m de resolução, normalização por 0.0001, tamanho de entrada 512×512).

Definição de ordem das bandas e metadados para cada banda.

Parâmetros de classes (nuvem espessa, nuvem fina, sombra).

Essas mudanças permitem alternar entre os modelos apenas ajustando o parâmetro architecture e o arquivo de pesos, sem quebrar a estrutura existente do pipeline.